### PR TITLE
Support pod tolerations on deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -247,6 +247,16 @@ resource "kubernetes_deployment" "metrics_server" {
         }
 
         node_selector = var.kubernetes_deployment_node_selector
+
+        dynamic toleration {
+          for_each = var.kubernetes_deployment_tolerations
+          content {
+            key      = toleration.value.key
+            operator = toleration.value.operator
+            value    = toleration.value.value
+            effect   = toleration.value.effect
+          }
+        }
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,17 @@ variable "kubernetes_deployment_node_selector" {
   description = "Node selectors for kubernetes deployment"
 }
 
+variable "kubernetes_deployment_tolerations" {
+  type = list(object({
+    key = string
+    operator = string
+    value = string
+    effect = string
+  }))
+
+  default = []
+}
+
 variable "metrics_server_image" {
   type = string
   default = "k8s.gcr.io/metrics-server-amd64"


### PR DESCRIPTION
Add `kubernetes_deployment_tolerations` variable and use its value
to configure pod tolerations on metrics server deployment.

This allows for deploying metrics server onto nodes with taints.