### PR TITLE
Fixing prefix for metrics-service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,7 +172,7 @@ resource "kubernetes_api_service" "metrics_server" {
   }
   spec {
     service {
-      name = "metrics-server"
+      name = "${var.kubernetes_resources_name_prefix}metrics-server"
       namespace = var.kubernetes_namespace
     }
 


### PR DESCRIPTION
If kubernetes_resources_name_prefix not empty, then metrics-server not working properly because  "kubernetes_api_service" "metrics_server" has no prefix